### PR TITLE
fix: gracefully shutdown on crtl+c

### DIFF
--- a/client/src/client/a2a_agent_mcp_tool.py
+++ b/client/src/client/a2a_agent_mcp_tool.py
@@ -71,4 +71,7 @@ async def get_weather(location_prompt: str, transaction_id: str) -> str:
 
 
 if __name__ == '__main__':
-    mcp.run(transport="sse")
+    try:
+        mcp.run(transport="sse")
+    except KeyboardInterrupt as kie:
+        pass


### PR DESCRIPTION
Added a try - except block around the mcp.run part of the Fast MCP server, to handle `KeyboardInterrupt` errors more gracefully. 
Before:
```
^CINFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [83716]
Traceback (most recent call last):
  File "/home/kasper/.local/share/uv/python/cpython-3.13.2-linux-x86_64-gnu/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/kasper/.local/share/uv/python/cpython-3.13.2-linux-x86_64-gnu/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kasper/developer/github.com/kaaquist/playing-w-a2a/client/src/client/a2a_agent_mcp_tool.py", line 74, in <module>
    mcp.run(transport="sse")
    ~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/kasper/developer/github.com/kaaquist/playing-w-a2a/client/.venv/lib/python3.13/site-packages/mcp/server/fastmcp/server.py", line 236, in run
    anyio.run(lambda: self.run_sse_async(mount_path))
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kasper/developer/github.com/kaaquist/playing-w-a2a/client/.venv/lib/python3.13/site-packages/anyio/_core/_eventloop.py", line 74, in run
    return async_backend.run(func, args, {}, backend_options)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kasper/developer/github.com/kaaquist/playing-w-a2a/client/.venv/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 2310, in run
    return runner.run(wrapper())
           ~~~~~~~~~~^^^^^^^^^^^
  File "/home/kasper/.local/share/uv/python/cpython-3.13.2-linux-x86_64-gnu/lib/python3.13/asyncio/runners.py", line 123, in run
    raise KeyboardInterrupt()
KeyboardInterrupt
```
After: 
```
> uv run src/client/a2a_agent_mcp_tool.py
INFO:     Started server process [97512]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:8090 (Press CTRL+C to quit)
^CINFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [97512]
```
